### PR TITLE
Fix factory for laravel 5.5

### DIFF
--- a/src/View/Factory.php
+++ b/src/View/Factory.php
@@ -51,7 +51,7 @@ class Factory extends IlluminateViewFactory
         // the caller for rendering or performing other view manipulations on this.
         $data = array_merge($mergeData, $this->parseData($data));
 
-        return tap($this->viewInstance($view, $path, $data), function ($view) {
+        return tap(new View($this, $this->getEngineFromPath($path), $view, $path, $data, $this->shortcode), function ($view) {
             $this->callCreator($view);
         });
     }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace Webwizo\Shortcodes;
+
+
+use Webwizo\Shortcodes\View\View;
+
+class FactoryTest extends TestCase
+{
+
+    public function testMake()
+    {
+        $factory = app('view');
+
+        $factory->addNamespace('Test',  __DIR__.'\views');
+
+        $this->assertTrue($factory->make('Test::test') instanceof View);
+    }
+}

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -13,7 +13,7 @@ class FactoryTest extends TestCase
     {
         $factory = app('view');
 
-        $factory->addNamespace('Test',  __DIR__.'\views');
+        $factory->addNamespace('Test',  __DIR__.'/views');
 
         $this->assertTrue($factory->make('Test::test') instanceof View);
     }


### PR DESCRIPTION
The mistake was in previous pull request. Was used `\Illuminate\View\View` instance instead `\Webwise\Shortcodes\View\View`
That was fixed. Also, added test for checking this