### PR TITLE
allow Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "webwizo/laravel-shortcodes",
     "type": "library",
-    "description": "Wordpress like shortcodes for Laravel 5 and 6",
+    "description": "Wordpress like shortcodes for Laravel 5, 6, and 7",
     "keywords": [
         "laravel",
         "wordpress",
@@ -18,9 +18,9 @@
         }
     ],
     "require": {
-        "illuminate/view": "5.6.x|5.7.x|5.8.x|^6.0",
-        "illuminate/support": "5.6.x|5.7.x|5.8.x|^6.0",
-        "illuminate/contracts": "5.6.x|5.7.x|5.8.x|^6.0",
+        "illuminate/view": "5.6.x|5.7.x|5.8.x|^6.0|^7.0",
+        "illuminate/support": "5.6.x|5.7.x|5.8.x|^6.0|^7.0",
+        "illuminate/contracts": "5.6.x|5.7.x|5.8.x|^6.0|^7.0",
         "php": "^7.2"
     },
     "require-dev": {


### PR DESCRIPTION
if you don't want to continue supporting super old versions of Laravel, you might consider breaking off a v2 of this package that only supports Laravel 7, instead of this PR.