### PR TITLE
update to Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "webwizo/laravel-shortcodes",
     "type": "library",
-    "description": "Wordpress like shortcodes for Laravel 5 and 6",
+    "description": "Wordpress like shortcodes for Laravel 7",
     "keywords": [
         "laravel",
         "wordpress",
@@ -18,9 +18,9 @@
         }
     ],
     "require": {
-        "illuminate/view": "5.6.x|5.7.x|5.8.x|^6.0",
-        "illuminate/support": "5.6.x|5.7.x|5.8.x|^6.0",
-        "illuminate/contracts": "5.6.x|5.7.x|5.8.x|^6.0",
+        "illuminate/view": "^7.0",
+        "illuminate/support": "^7.0",
+        "illuminate/contracts": "^7.0",
         "php": "^7.2"
     },
     "require-dev": {


### PR DESCRIPTION
drop support for 5.x and 6.x.  support Laravel 7.

this is option 2. if you merge this one, then you can do a v2 release of this package.