### PR TITLE
Fixing PSR-12 Coding Standard: Move Namespace Declaration to New Line

### DIFF
--- a/src/Shortcode.php
+++ b/src/Shortcode.php
@@ -1,4 +1,6 @@
-<?php namespace Webwizo\Shortcodes;
+<?php
+
+namespace Webwizo\Shortcodes;
 
 use Webwizo\Shortcodes\Compilers\ShortcodeCompiler;
 


### PR DESCRIPTION
Hello,

This pull request addresses a coding standard issue in accordance with PSR-12. The standard specifies that 

> when the opening <?php tag is on the first line of the file, it MUST be on its own line with no other statements.