### PR TITLE
Updated actions and added Laravel 13 Support 

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -32,7 +32,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.1, '8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4', '8.5']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "webwizo/laravel-shortcodes",
     "type": "library",
-    "description": "Wordpress like shortcodes for Laravel 5, 6, 7, 8, 9, 10, 11 and 12",
+    "description": "Wordpress like shortcodes for Laravel 5, 6, 7, 8, 9, 10, 11, 12 and 13",
     "keywords": [
         "laravel",
         "wordpress",
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "illuminate/view": "5.6.x|5.7.x|5.8.x|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "5.6.x|5.7.x|5.8.x|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/contracts": "5.6.x|5.7.x|5.8.x|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/view": "5.6.x|5.7.x|5.8.x|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "5.6.x|5.7.x|5.8.x|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "5.6.x|5.7.x|5.8.x|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "php": "^7.2|^8.0|^8.1|^8.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0|^11.5.3",
-        "orchestra/testbench": "~3.9.0|^4.0|^5.0|^6.0|^7.0|^8.0|^10.0",
+        "orchestra/testbench": "~3.9.0|^4.0|^5.0|^6.0|^7.0|^8.0|^10.0|^11.0",
         "scrutinizer/ocular": "^1.5",
         "squizlabs/php_codesniffer": "~2.3|^3.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     "require-dev": {
         "phpunit/phpunit": "^11.5.3",
         "orchestra/testbench": "^9.0|^10.0|^11.0",
-        "scrutinizer/ocular": "^1.5",
         "squizlabs/php_codesniffer": "~2.3|^3.7"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/view": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
         "illuminate/contracts": "^11.0|^12.0|^13.0",
-        "php": "^7.2|^8.0|^8.1|^8.2"
+        "php": "^8.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.3",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "webwizo/laravel-shortcodes",
     "type": "library",
-    "description": "Wordpress like shortcodes for Laravel 5, 6, 7, 8, 9, 10, 11, 12 and 13",
+    "description": "Wordpress like shortcodes for Laravel 11, 12 and 13",
     "keywords": [
         "laravel",
         "wordpress",
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "illuminate/view": "5.6.x|5.7.x|5.8.x|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
-        "illuminate/support": "5.6.x|5.7.x|5.8.x|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
-        "illuminate/contracts": "5.6.x|5.7.x|5.8.x|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/view": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "php": "^7.2|^8.0|^8.1|^8.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.0|^11.5.3",
-        "orchestra/testbench": "~3.9.0|^4.0|^5.0|^6.0|^7.0|^8.0|^10.0|^11.0",
+        "phpunit/phpunit": "^11.5.3",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "scrutinizer/ocular": "^1.5",
         "squizlabs/php_codesniffer": "~2.3|^3.7"
     },


### PR DESCRIPTION
- Added Laravel 13 support
- Updated actions/checkout and actions/cache
- Dropped EOL PHP versions
- Added PHP 8.5 to the test matrix
- Removed scrutinizer/ocular from require-dev (unmaintained; last release ~4 years ago) and it conflicts with symfony/process 