### PR TITLE
Fix #56, #51, #37, #59 — attributes, void tags, nested same-name shortcodes

### DIFF
--- a/src/Compilers/ShortcodeCompiler.php
+++ b/src/Compilers/ShortcodeCompiler.php
@@ -137,9 +137,11 @@ class ShortcodeCompiler
      */
     protected function renderShortcodes($value)
     {
-        $pattern = $this->getRegex();
+        if (!$this->hasShortcodes()) {
+            return $value;
+        }
 
-        return preg_replace_callback("/{$pattern}/s", [$this, 'render'], $value);
+        return $this->replaceShortcodesInString($value, [$this, 'render']);
     }
     
     // get view data
@@ -311,7 +313,12 @@ class ShortcodeCompiler
      */
     protected function getShortcodeNames()
     {
-        return join('|', array_map('preg_quote', array_keys($this->registered)));
+        $names = array_keys($this->registered);
+        usort($names, function ($a, $b) {
+            return strlen($b) <=> strlen($a);
+        });
+
+        return implode('|', array_map('preg_quote', $names));
     }
 
     /**
@@ -339,9 +346,8 @@ class ShortcodeCompiler
         if (empty($this->registered)) {
             return $content;
         }
-        $pattern = $this->getRegex();
 
-        return preg_replace_callback("/{$pattern}/s", [$this, 'stripTag'], $content);
+        return $this->replaceShortcodesInString($content, [$this, 'stripTag']);
     }
 
     /**
@@ -375,7 +381,228 @@ class ShortcodeCompiler
 
         return $m[1] . $m[6];
     }
-    
+
+    /**
+     * Replace shortcodes left-to-right using balanced matching for nested tags with the same name (GitHub #59).
+     *
+     * @param  callable(array): string  $callback
+     */
+    protected function replaceShortcodesInString(string $value, callable $callback): string
+    {
+        $namesPattern = $this->getShortcodeNames();
+        if ($namesPattern === '') {
+            return $value;
+        }
+
+        $out = '';
+        $offset = 0;
+        $len = strlen($value);
+
+        while ($offset < $len) {
+            if (!preg_match('/\[\[|\[(' . $namesPattern . ')(?![\w-])/s', $value, $m, PREG_OFFSET_CAPTURE, $offset)) {
+                $out .= substr($value, $offset);
+                break;
+            }
+
+            $matchStart = (int) $m[0][1];
+            $token = $m[0][0];
+
+            if ($token === '[[') {
+                $out .= substr($value, $offset, $matchStart - $offset);
+                $out .= '[';
+                $offset = $matchStart + 2;
+
+                continue;
+            }
+
+            $out .= substr($value, $offset, $matchStart - $offset);
+
+            $name = $m[1][0];
+            $openBracket = $matchStart;
+
+            $openEnd = $this->findEndOfOpeningShortcodeTag($value, $openBracket);
+            if ($openEnd === null) {
+                $out .= '[';
+                $offset = $openBracket + 1;
+
+                continue;
+            }
+
+            $matchArr = $this->composeShortcodeMatch($value, $openBracket, $openEnd, $name);
+            if ($matchArr === null) {
+                $out .= '[';
+                $offset = $openBracket + 1;
+
+                continue;
+            }
+
+            $out .= $callback($matchArr);
+            $offset = $matchArr['_end'];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return int|null byte offset immediately after the opening tag's closing `]`
+     */
+    protected function findEndOfOpeningShortcodeTag(string $value, int $openBracket): ?int
+    {
+        $len = strlen($value);
+        $i = $openBracket + 1;
+        if ($i >= $len) {
+            return null;
+        }
+
+        if ($value[$i] === '[') {
+            return null;
+        }
+
+        $quote = null;
+        for (; $i < $len; $i++) {
+            $c = $value[$i];
+            if ($quote !== null) {
+                if ($c === '\\') {
+                    $i++;
+
+                    continue;
+                }
+                if ($c === $quote) {
+                    $quote = null;
+                }
+
+                continue;
+            }
+            if ($c === '"' || $c === "'") {
+                $quote = $c;
+
+                continue;
+            }
+            if ($c === ']') {
+                return $i + 1;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>|null  preg-style match array plus `_end` (exclusive end offset in $value)
+     */
+    protected function composeShortcodeMatch(string $value, int $openBracket, int $openEnd, string $name): ?array
+    {
+        $openTag = substr($value, $openBracket, $openEnd - $openBracket);
+        $isSelfClosing = (bool) preg_match('#/\s*\]\s*$#', $openTag);
+
+        $nameStart = $openBracket + 1;
+        if ($nameStart + strlen($name) > $openEnd) {
+            return null;
+        }
+
+        if (strcasecmp(substr($value, $nameStart, strlen($name)), $name) !== 0) {
+            return null;
+        }
+
+        $attrsStart = $nameStart + strlen($name);
+        $attrsRaw = substr($value, $attrsStart, $openEnd - 1 - $attrsStart);
+        if ($isSelfClosing) {
+            $attrsRaw = rtrim($attrsRaw);
+            $attrsRaw = preg_replace('#/\s*$#', '', $attrsRaw) ?? '';
+        }
+
+        if ($isSelfClosing) {
+            $fullEnd = $openEnd;
+            $content = '';
+
+            return [
+                0 => substr($value, $openBracket, $fullEnd - $openBracket),
+                1 => '',
+                2 => $name,
+                3 => $attrsRaw,
+                4 => '/',
+                5 => $content,
+                6 => '',
+                '_end' => $fullEnd,
+            ];
+        }
+
+        $balanced = $this->findBalancedClosingTag($value, $openEnd, $name);
+        if ($balanced === null) {
+            // Void shortcode: [tag attrs] with no matching [/tag] (GitHub #51).
+            $fullEnd = $openEnd;
+
+            return [
+                0 => substr($value, $openBracket, $fullEnd - $openBracket),
+                1 => '',
+                2 => $name,
+                3 => $attrsRaw,
+                4 => '/',
+                5 => '',
+                6 => '',
+                '_end' => $fullEnd,
+            ];
+        }
+
+        [$closeStart, $closeEnd] = $balanced;
+        $content = substr($value, $openEnd, $closeStart - $openEnd);
+        $fullEnd = $closeEnd;
+
+        return [
+            0 => substr($value, $openBracket, $fullEnd - $openBracket),
+            1 => '',
+            2 => $name,
+            3 => $attrsRaw,
+            4 => '',
+            5 => $content,
+            6 => '',
+            '_end' => $fullEnd,
+        ];
+    }
+
+    /**
+     * @return array{0: int, 1: int}|null  [closeBracketStart, exclusiveEndAfterCloseTag]
+     */
+    protected function findBalancedClosingTag(string $value, int $contentStart, string $name): ?array
+    {
+        $len = strlen($value);
+        $depth = 1;
+        $pos = $contentStart;
+        $openRe = '/\[(?!\/)' . preg_quote($name, '/') . '(?![\w-])/i';
+        $closeRe = '/\[\/' . preg_quote($name, '/') . '\]/i';
+
+        while ($pos < $len && $depth > 0) {
+            $hasOpen = preg_match($openRe, $value, $mo, PREG_OFFSET_CAPTURE, $pos);
+            $hasClose = preg_match($closeRe, $value, $mc, PREG_OFFSET_CAPTURE, $pos);
+
+            if (!$hasClose) {
+                return null;
+            }
+
+            $openPos = $hasOpen ? (int) $mo[0][1] : PHP_INT_MAX;
+            $closePos = (int) $mc[0][1];
+
+            if ($hasOpen && $openPos < $closePos) {
+                $depth++;
+                $nextOpenEnd = $this->findEndOfOpeningShortcodeTag($value, $openPos);
+                if ($nextOpenEnd === null) {
+                    return null;
+                }
+                $pos = $nextOpenEnd;
+
+                continue;
+            }
+
+            $depth--;
+            $closeEnd = $closePos + strlen($mc[0][0]);
+            if ($depth === 0) {
+                return [$closePos, $closeEnd];
+            }
+            $pos = $closeEnd;
+        }
+
+        return null;
+    }
+
     /**
      * Get registered shortcodes
      *

--- a/src/Compilers/ShortcodeCompiler.php
+++ b/src/Compilers/ShortcodeCompiler.php
@@ -277,8 +277,8 @@ class ShortcodeCompiler
         $text = htmlspecialchars_decode($text, ENT_QUOTES);
 
         $attributes = [];
-        // attributes pattern
-        $pattern = '/(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*\'([^\']*)\'(?:\s|$)|(\w+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/';
+        // Match WordPress-style attributes; allow `]` after a value (issue #56) and hyphenated keys (WP 4.4+).
+        $pattern = '/([\w-]+)\s*=\s*"([^"]*)"(?:\s|\]|$)|([\w-]+)\s*=\s*\'([^\']*)\'(?:\s|\]|$)|([\w-]+)\s*=\s*([^\s\'"]+)(?:\s|\]|$)|"([^"]*)"(?:\s|\]|$)|\'([^\']*)\'(?:\s|\]|$)|(\S+)(?:\s|\]|$)/';
         // Match
         if (preg_match_all($pattern, preg_replace('/[\x{00a0}\x{200b}]+/u', " ", $text), $match, PREG_SET_ORDER)) {
             foreach ($match as $m) {
@@ -290,8 +290,10 @@ class ShortcodeCompiler
                     $attributes[strtolower($m[5])] = stripcslashes($m[6]);
                 } elseif (isset($m[7]) && strlen($m[7])) {
                     $attributes[] = stripcslashes($m[7]);
-                } elseif (isset($m[8])) {
+                } elseif (isset($m[8]) && strlen($m[8])) {
                     $attributes[] = stripcslashes($m[8]);
+                } elseif (isset($m[9])) {
+                    $attributes[] = stripcslashes($m[9]);
                 }
             }
         } else {

--- a/tests/GitHubIssue37MalformedBracketsTest.php
+++ b/tests/GitHubIssue37MalformedBracketsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Webwizo\Shortcodes;
+
+/**
+ * GitHub #37 — prose that contains `[` must not be eaten when it is not a registered shortcode.
+ *
+ * @see https://github.com/webwizo/laravel-shortcodes/issues/37
+ */
+class GitHubIssue37MalformedBracketsTest extends TestCase
+{
+    public function test_square_bracket_text_that_does_not_match_a_registered_tag_is_left_unchanged(): void
+    {
+        $this->shortcode->register('gallery', function () {
+            return 'G';
+        });
+
+        $input = "THANK YOU VERY MUCH!\n[I AM SO SORRY THAT MY ENGLISH IS POOR ....\n<em class=\"fab fa-youtube\"></em>\n";
+
+        $this->assertSame($input, $this->shortcode->compile($input));
+    }
+
+    public function test_opening_bracket_followed_by_space_is_not_treated_as_shortcode(): void
+    {
+        $this->shortcode->register('b', fn ($_, $c) => '<b>' . $c . '</b>');
+
+        $input = 'Text [ not a shortcode ] more';
+
+        $this->assertSame($input, $this->shortcode->compile($input));
+    }
+}

--- a/tests/GitHubIssue51ShortcodeAtBeginningTest.php
+++ b/tests/GitHubIssue51ShortcodeAtBeginningTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Webwizo\Shortcodes;
+
+/**
+ * GitHub #51 — shortcode as the first content in a rendered view must not break attribute handling.
+ *
+ * @see https://github.com/webwizo/laravel-shortcodes/issues/51
+ */
+class GitHubIssue51ShortcodeAtBeginningTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        view()->addNamespace('Gh51', __DIR__ . '/views');
+    }
+
+    public function test_blade_whose_first_line_starts_with_self_closing_shortcode_renders_attributes(): void
+    {
+        $this->shortcode->register('library', function ($shortcode) {
+            return 'TYPE:' . (string) $shortcode->type;
+        });
+
+        $html = view('Gh51::issue51-start')->withShortcodes()->render();
+
+        $this->assertStringContainsString('TYPE:document', $html);
+    }
+}

--- a/tests/GitHubIssue56QuotedSpacesTest.php
+++ b/tests/GitHubIssue56QuotedSpacesTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Webwizo\Shortcodes;
+
+/**
+ * GitHub #56 — attribute values with spaces inside single-quoted values must stay one string.
+ *
+ * @see https://github.com/webwizo/laravel-shortcodes/issues/56
+ */
+class GitHubIssue56QuotedSpacesTest extends TestCase
+{
+    public function test_single_quoted_attribute_value_with_spaces_is_not_split_into_numeric_keys(): void
+    {
+        $captured = null;
+
+        $this->shortcode->register('pdfmodal', function ($shortcode) use (&$captured) {
+            $captured = $shortcode->toArray();
+
+            return 'ok';
+        });
+
+        $this->shortcode->compile(
+            "[pdfmodal path=/files/docs.pdf modaltitle='Flat Rate Cost']Click Here[/pdfmodal]"
+        );
+
+        $this->assertNotNull($captured);
+        $this->assertArrayHasKey('modaltitle', $captured);
+        $this->assertSame('Flat Rate Cost', $captured['modaltitle']);
+        $this->assertArrayNotHasKey(0, $captured, 'Spaces must not create numeric-indexed attribute fragments');
+    }
+
+    public function test_double_quoted_value_with_spaces_before_closing_bracket(): void
+    {
+        $captured = null;
+
+        $this->shortcode->register('widget', function ($shortcode) use (&$captured) {
+            $captured = $shortcode->toArray();
+
+            return 'x';
+        });
+
+        $this->shortcode->compile('[widget title="One Two Three"][/widget]');
+
+        $this->assertSame('One Two Three', $captured['title']);
+    }
+
+    public function test_parse_attributes_allows_closing_bracket_immediately_after_quoted_value(): void
+    {
+        $compiler = $this->app->make('shortcode.compiler');
+        $method = (new \ReflectionClass($compiler))->getMethod('parseAttributes');
+        $method->setAccessible(true);
+
+        // Artificial input may leave `]` for a follow-up token; real shortcode tags never pass `]` here.
+        $attrs = $method->invoke($compiler, ' modaltitle="Flat Rate Cost"]');
+
+        $this->assertSame('Flat Rate Cost', $attrs['modaltitle']);
+    }
+
+    public function test_hyphenated_attribute_names_are_recognized(): void
+    {
+        $captured = null;
+
+        $this->shortcode->register('box', function ($shortcode) use (&$captured) {
+            $captured = $shortcode->toArray();
+
+            return 'x';
+        });
+
+        $this->shortcode->compile('[box data-size="large"][/box]');
+
+        $this->assertSame('large', $captured['data-size']);
+    }
+}

--- a/tests/GitHubIssue59NestedSameNameTest.php
+++ b/tests/GitHubIssue59NestedSameNameTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Webwizo\Shortcodes;
+
+/**
+ * GitHub #59 — nested shortcodes that share the same tag name.
+ *
+ * @see https://github.com/webwizo/laravel-shortcodes/issues/59
+ */
+class GitHubIssue59NestedSameNameTest extends TestCase
+{
+    public function test_nested_div_shortcodes_produce_correctly_nested_markup(): void
+    {
+        $this->shortcode->register('div', function ($shortcode, $content) {
+            $class = $shortcode->class ? ' class="' . e($shortcode->class) . '"' : '';
+
+            return '<div' . $class . '>' . $content . '</div>';
+        });
+
+        $out = $this->shortcode->compile(
+            '[div class="row"][div class="col-md-6"]Left[/div][div class="col-md-6"]Right[/div][/div]'
+        );
+
+        $this->assertStringContainsString('<div class="row">', $out);
+        $this->assertStringContainsString('<div class="col-md-6">Left</div>', $out);
+        $this->assertStringContainsString('<div class="col-md-6">Right</div>', $out);
+        $this->assertStringEndsWith('</div>', $out);
+    }
+}

--- a/tests/views/issue51-start.blade.php
+++ b/tests/views/issue51-start.blade.php
@@ -1,0 +1,2 @@
+[library type="document" id="68"]
+<p>after</p>


### PR DESCRIPTION
## Summary

This PR fixes attribute parsing edge cases, improves shortcode scanning for **nested same-name tags** and **void self-closing tags**, and adds PHPUnit regression tests tied to open GitHub issues.

---

### #56 — attribute having space value converts to weird array

**Problem:** Quoted attribute values could be parsed incorrectly when terminators did not match the old `(?:\s|$)` tail; hyphenated attribute names (`data-*`) were not matched like WordPress.

**Resolution:**

- Updated `ShortcodeCompiler::parseAttributes()` to align with WordPress `get_shortcode_atts_regex()`:
  - Allow `\s`, `]`, or end-of-string after a quoted or unquoted value.
  - Use `[\w-]+` for keys (hyphenated attributes).
  - Support the anonymous single-quoted branch (`m[9]`) like WordPress.

**Tests:** `tests/GitHubIssue56QuotedSpacesTest.php`

---

### #51 — Problem with shortcode at beginning

**Problem:** A self-closing shortcode such as `[library type="document" id="68"]` as the first line of rendered Blade output could fail because there is no `[/library]` closing tag.

**Resolution:**

- The new scanner treats **`[name attrs]` with no matching `[/name]`** as a **void (self-closing)** shortcode, consistent with typical CMS shortcodes.
- Regression Blade view + test ensure the first line of a view can start with that form.

**Tests:** `tests/GitHubIssue51ShortcodeAtBeginningTest.php`, `tests/views/issue51-start.blade.php`

---

### #37 — Malformed shortcodes cause strange output

**Problem:** User content that looks like `[` prose (e.g. `[I AM SO SORRY ...`) should not be altered when it does not match a registered tag.

**Resolution:**

- Confirmed behaviour with the new scanner + registered tags: only known tag names are interpreted; other `[` text is left unchanged.
- Added explicit regression tests so this does not regress.

**Tests:** `tests/GitHubIssue37MalformedBracketsTest.php`

---

### #59 — Nested same name tag shortcodes

**Problem:** Nested shortcodes with the **same** tag name (e.g. multiple `[div]…[/div]`) were matched with the old single-regex approach so the **first** `[/div]` closed the outer tag incorrectly.

**Resolution:**

- Replaced regex-only replacement in `renderShortcodes()` and `strip()` with a **left-to-right scanner** that:
  - Finds opening tags with quoted-attribute aware scanning to the closing `]`.
  - For enclosing tags, finds the matching `[/name]` using **depth counting** for that tag name (case-insensitive close match).
- Sorts registered tag names **longest-first** in the alternation to avoid prefix collisions (e.g. `div` vs `divider`).

**Tests:** `tests/GitHubIssue59NestedSameNameTest.php`

---

## Commits (on this branch)

1. `fix: parse shortcode attributes after quoted values and hyphenated keys (#56)`
2. `test: Blade view may start with a self-closing shortcode (#51)`
3. `test: prose with [ brackets must pass through when not a tag (#37)`
4. `fix: balance nested shortcodes and void [tag] forms (#59, #51)`

---

## Verification

```bash
composer install
vendor/bin/phpunit
```

---

## After merge

Merge this PR into `master`, then tag / release as usual for Packagist.
