### PR TITLE
Preserve accumulated view data when rendering nested shortcode views

### DIFF
--- a/src/Compilers/ShortcodeCompiler.php
+++ b/src/Compilers/ShortcodeCompiler.php
@@ -156,7 +156,7 @@ class ShortcodeCompiler
     // get view data
     public function viewData($viewData)
     {
-        $this->_viewData = $viewData;
+        $this->_viewData = array_merge($this->_viewData ?? [], $viewData);
         return $this;
     }
 

--- a/tests/ShortcodeTest.php
+++ b/tests/ShortcodeTest.php
@@ -41,4 +41,21 @@ class ShortcodeTest extends TestCase
 
         $this->assertEmpty($compiled);
     }
+
+    public function testViewDataIsMergedAcrossNestedRenders(): void
+    {
+        $compiler = app('shortcode.compiler');
+
+        $compiler->add('shortcode', function ($shortcode, $content, $compiler, $name, $viewData) {
+            return json_encode($viewData);
+        });
+
+        $compiler->enable();
+        $compiler->viewData(['parent' => 'layout']);
+        $compiler->viewData(['child' => 'partial']);
+
+        $compiled = $compiler->compile('[shortcode][/shortcode]');
+
+        $this->assertSame('{"parent":"layout","child":"partial"}', $compiled);
+    }
 }


### PR DESCRIPTION
## Summary

This fixes an issue where view data can be lost when shortcode-enabled views render nested views/templates.

`ShortcodeCompiler` is registered as a singleton, and each shortcode-enabled view render calls `viewData($this->getData())` before compiling shortcodes. Before this change, each call replaced the compiler’s existing view data. In nested render flows, that means data from the outer view can be overwritten by data from the inner view before shortcode callbacks receive it.

This PR updates `ShortcodeCompiler::viewData()` to merge incoming view data with any data already attached to the compiler, preserving parent view data while still allowing later/nested values to be added.

## Why This Is Needed

When templates are nested, shortcode callbacks may need access to view data from the outer render context. Replacing the stored view data causes that context to disappear. Merging the data keeps the accumulated render context available to shortcode callbacks.

## Tests

Added a regression test covering sequential `viewData()` calls before shortcode compilation:

- verifies parent view data remains available
- verifies child/nested view data is also included
- confirms the previous replacement behavior would drop the parent data

Validation run locally:

```bash
composer test
```

Result:
```
Tests: 18, Assertions: 32
```

Also checked touched files against PSR-2 with PHPCS. There are no PSR-2 errors in the touched files. Existing warnings remain in `ShortcodeCompiler.php` for pre-existing style issues unrelated to this change.

## Tradeoffs / Considerations
This changes `viewData()` from replacement semantics to merge semantics. If any consumer intentionally relied on a later render completely replacing earlier view data, that behavior will change.

For duplicate keys, `array_merge()` keeps PHP’s normal behavior: later values override earlier values. That means nested/child view data can still override parent values for the same key, while unrelated parent keys are preserved.

The change is intentionally small and scoped to the existing compiler data flow.